### PR TITLE
Update 0.9.4 beta

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Declare files that will always have LF line endings on checkout.
+# Fix shell scripts with lines ending with "CRLF" on Windows
+* text=auto
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 LABEL Author="@apazga"
 
 # pgModeler version to use
-ENV PG_VERSION 0.9.4-alpha
+ENV PG_VERSION 0.9.4-beta
 
 ADD https://codeload.github.com/pgmodeler/pgmodeler/tar.gz/v${PG_VERSION} /usr/local/src/
 WORKDIR /usr/local/src/
@@ -10,7 +10,7 @@ WORKDIR /usr/local/src/
 # Install dependencies
 RUN BUILD_PKGS="make g++ qt5-qmake libxml2-dev \
   libpq-dev pkg-config libqt5svg5-dev" \
-  && RUNTIME_PKGS="qt5-default libqt5svg5 postgresql-server-dev-9.6" \
+  && RUNTIME_PKGS="qt5-default libqt5svg5 postgresql-server-dev-all" \
   && DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
   && apt-get -y install ${BUILD_PKGS} ${RUNTIME_PKGS}

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ If you want to build the image using the Dockerfile provided (it can take a whil
 - 0.9.3-beta1
 - 0.9.3
 - 0.9.4-alpha
+- 0.9.4-beta
 
-Full changelog: <https://github.com/pgmodeler/pgmodeler/blob/v0.9.4-alpha/CHANGELOG.md>
+Full changelog: <https://github.com/pgmodeler/pgmodeler/blob/v0.9.4-beta/CHANGELOG.md>
 
 ## Acknowledgment
 

--- a/run.ps1
+++ b/run.ps1
@@ -9,7 +9,7 @@
 
 # Try to get your LAN IP automatically
 Set-Variable -name IPADDR -value ((Get-NetIPAddress).IPAddress -like "192*").Trim()
-Set-Variable -name DISPLAY -value $IPADDR":0.0"
+Set-Variable -name DISPLAY -value 'host.docker.internal:0.0'
 
 Write-Host $DISPLAY
 docker run --rm --name="apazga-pgmodeler" -ti -e DISPLAY=$DISPLAY -v $PSScriptRoot/data:/data apazga/docker-pgmodeler:0.9.4-alpha


### PR DESCRIPTION
Hello!

The 0.9.4-beta has been published a few days ago. Your docker image is so convenient I would love it to have the latest update. Here is how I could build it.

You can run the image from here:
https://hub.docker.com/r/merinorus/docker-pgmodeler

It's the same as yours but the file is much larger, I'm not a Docker expert. Feel free to update your dockerhub image so I can delete mine.

Thank you for your work!